### PR TITLE
Complete French news locale metadata

### DIFF
--- a/locale/fr-fr/ca.voc
+++ b/locale/fr-fr/ca.voc
@@ -1,2 +1,2 @@
-Catalan
 Catalogne
+catalanes

--- a/locale/fr-fr/de.voc
+++ b/locale/fr-fr/de.voc
@@ -1,1 +1,1 @@
-Allemand
+allemandes

--- a/locale/fr-fr/en-au.voc
+++ b/locale/fr-fr/en-au.voc
@@ -1,2 +1,2 @@
-australia
-australian
+Australie
+australiennes

--- a/locale/fr-fr/en-ca.voc
+++ b/locale/fr-fr/en-ca.voc
@@ -1,2 +1,2 @@
-canada
-canadian
+Canada
+canadiennes

--- a/locale/fr-fr/en-gb.voc
+++ b/locale/fr-fr/en-gb.voc
@@ -1,3 +1,2 @@
-UK
-british
-royaume uni
+Royaume-Uni
+britanniques

--- a/locale/fr-fr/en-us.voc
+++ b/locale/fr-fr/en-us.voc
@@ -1,3 +1,3 @@
-Etats unis
-america
+américaines
 américains
+États-Unis

--- a/locale/fr-fr/en.voc
+++ b/locale/fr-fr/en.voc
@@ -1,1 +1,1 @@
-Anglais
+anglais

--- a/locale/fr-fr/es.voc
+++ b/locale/fr-fr/es.voc
@@ -1,1 +1,1 @@
-Espagnol
+espagnoles

--- a/locale/fr-fr/euro.voc
+++ b/locale/fr-fr/euro.voc
@@ -1,2 +1,2 @@
-euro
-european
+Europe
+européennes

--- a/locale/fr-fr/fi.voc
+++ b/locale/fr-fr/fi.voc
@@ -1,2 +1,2 @@
-finland
-finnish
+Finlande
+finlandaises

--- a/locale/fr-fr/fr.voc
+++ b/locale/fr-fr/fr.voc
@@ -1,2 +1,2 @@
-Français
-france
+France
+françaises

--- a/locale/fr-fr/fr24.voc
+++ b/locale/fr-fr/fr24.voc
@@ -1,3 +1,3 @@
-France
 France 24
+France vingt-quatre
 France24

--- a/locale/fr-fr/global_news.intent
+++ b/locale/fr-fr/global_news.intent
@@ -1,0 +1,9 @@
+donne-moi les actualités internationales
+donne-moi les actualités mondiales
+je veux les actualités mondiales
+je veux les actualités internationales
+joue les actualités mondiales
+joue les actualités internationales
+quelles sont les nouvelles du monde
+quelles sont les actualités mondiales
+y a-t-il de grandes nouvelles dans le monde

--- a/locale/fr-fr/it.voc
+++ b/locale/fr-fr/it.voc
@@ -1,2 +1,2 @@
 Italie
-Italien
+italiennes

--- a/locale/fr-fr/news.error
+++ b/locale/fr-fr/news.error
@@ -1,0 +1,3 @@
+Je n'ai trouvé aucun flux d'actualités.
+Je n'ai pas réussi à récupérer les actualités. Réessayez plus tard.
+Il semble qu'aucun flux d'actualités ne soit disponible pour le moment.

--- a/locale/fr-fr/news.intent
+++ b/locale/fr-fr/news.intent
@@ -1,0 +1,16 @@
+je veux écouter les actualités
+je veux écouter les dernières actualités
+je veux écouter les actualités locales
+je veux écouter les actualités régionales
+donne-moi les actualités
+donne-moi les dernières actualités
+donne-moi les actualités locales
+donne-moi les actualités régionales
+joue les actualités
+joue les dernières actualités
+joue les actualités locales
+joue les actualités régionales
+quelles sont les actualités
+quelles sont les dernières actualités
+quelles sont les actualités locales
+quelles sont les actualités régionales

--- a/locale/fr-fr/news.voc
+++ b/locale/fr-fr/news.voc
@@ -1,3 +1,1 @@
-actualités
-infos
 nouvelles

--- a/locale/fr-fr/news.voc
+++ b/locale/fr-fr/news.voc
@@ -1,1 +1,3 @@
+actualités
+infos
 nouvelles

--- a/locale/fr-fr/nl.voc
+++ b/locale/fr-fr/nl.voc
@@ -1,3 +1,3 @@
-Nederlands ?
 Pays-Bas
-hollandaise
+hollandaises
+néerlandaises

--- a/locale/fr-fr/pt-pt.voc
+++ b/locale/fr-fr/pt-pt.voc
@@ -1,2 +1,2 @@
-Portugais
 Portugal
+portugaises

--- a/locale/fr-fr/ru.voc
+++ b/locale/fr-fr/ru.voc
@@ -1,2 +1,2 @@
-russe
-russie
+Russie
+russes

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,26 @@
+{
+  "skill_id": "ovos-skill-news.openvoiceos",
+  "source": "https://github.com/OpenVoiceOS/ovos-skill-news",
+  "extra_plugins": {
+    "core": [],
+    "PHAL": [],
+    "listener": [],
+    "audio": ["ovos-ocp-news-plugin"],
+    "media": ["ovos-ocp-news-plugin"],
+    "gui": []
+  },
+  "name": "Flux d'actualités",
+  "description": "Des flux d'actualités du monde entier.",
+  "examples": [
+    "Joue les actualités",
+    "Joue les actualités de NPR",
+    "Joue Euronews",
+    "Joue les actualités catalanes",
+    "Joue les actualités portugaises",
+    "Joue les actualités en espagnol"
+  ],
+  "tags": [
+    "actualités",
+    "information"
+  ]
+}

--- a/locale/fr-fr/sv.voc
+++ b/locale/fr-fr/sv.voc
@@ -1,1 +1,1 @@
-suédois
+suédoises

--- a/locale/fr-fr/world_news.voc
+++ b/locale/fr-fr/world_news.voc
@@ -1,0 +1,3 @@
+actualités mondiales
+actualités internationales
+nouvelles du monde

--- a/translations/fr-fr/vocabs.json
+++ b/translations/fr-fr/vocabs.json
@@ -1,82 +1,81 @@
 {
     "video.voc": [
-        "vid\u00e9o"
+        "vidéo"
     ],
     "rt.voc": [
         "Russie aujourd'hui"
     ],
     "it.voc": [
-        "Italien",
+        "italiennes",
         "Italie"
     ],
     "en-ca.voc": [
-        "canadian",
-        "canada"
+        "canadiennes",
+        "Canada"
     ],
     "nl.voc": [
-        "Nederlands ?",
-        "hollandaise",
+        "néerlandaises",
+        "hollandaises",
         "Pays-Bas"
     ],
     "ca.voc": [
         "Catalogne",
-        "Catalan"
+        "catalanes"
     ],
     "euronews.voc": [
         "euronews"
     ],
     "fr.voc": [
-        "france",
-        "Fran\u00e7ais"
+        "France",
+        "françaises"
     ],
     "es.voc": [
-        "Espagnol"
+        "espagnoles"
     ],
     "news.voc": [
         "nouvelles"
     ],
     "en-au.voc": [
-        "australian",
-        "australia"
+        "australiennes",
+        "Australie"
     ],
     "pt-pt.voc": [
-        "Portugais",
+        "portugaises",
         "Portugal"
     ],
     "euro.voc": [
-        "european",
-        "euro"
+        "européennes",
+        "Europe"
     ],
     "en.voc": [
-        "Anglais"
+        "anglais"
     ],
     "de.voc": [
-        "Allemand"
+        "allemandes"
     ],
     "fr24.voc": [
         "France 24",
         "France24",
-        "France"
+        "France vingt-quatre"
     ],
     "fi.voc": [
-        "finland",
-        "finnish"
+        "Finlande",
+        "finlandaises"
     ],
     "sv.voc": [
-        "su\u00e9dois"
+        "suédoises"
     ],
     "en-gb.voc": [
-        "royaume uni",
-        "british",
-        "UK"
+        "Royaume-Uni",
+        "britanniques"
     ],
     "ru.voc": [
-        "russe",
-        "russie"
+        "russes",
+        "Russie"
     ],
     "en-us.voc": [
-        "america",
-        "am\u00e9ricains",
-        "Etats unis"
+        "États-Unis",
+        "américaines",
+        "américains"
     ]
 }


### PR DESCRIPTION
## Summary
- add the missing French news intents, error dialog, world-news vocabulary, and localized skill metadata
- expand the French news keyword file so spoken requests use natural French terms

## Validation
- verified fr-fr file coverage against locale/en-us
- validated locale/fr-fr/skill.json parses as JSON